### PR TITLE
devops: add code quality workflow, check-version, CLAUDE.md, AI rules files

### DIFF
--- a/.cursorrules
+++ b/.cursorrules
@@ -1,0 +1,1 @@
+CLAUDE.md

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,1 @@
+../CLAUDE.md

--- a/.github/workflows/check-version.yml
+++ b/.github/workflows/check-version.yml
@@ -1,0 +1,44 @@
+name: Check Version
+
+on:
+  pull_request:
+    branches: [develop]
+    types: [opened, reopened, synchronize]
+    paths:
+      - package.json
+  workflow_dispatch:
+
+jobs:
+  check-version:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Get changed files
+        id: changed-files
+        uses: tj-actions/changed-files@v47
+        with:
+          files: package.json
+
+      - name: Get version from package.json
+        id: version
+        run: |
+          version=$(node -p "require(./package.json).version")
+          version_tag="v${version}"
+          echo "version_tag=${version_tag}" >> $GITHUB_OUTPUT
+          echo "Version tag: ${version_tag}"
+        shell: bash
+
+      - name: Check for existing tag
+        if: steps.changed-files.outputs.any_changed == true || github.event_name == workflow_dispatch
+        run: |
+          tag="${{ steps.version.outputs.version_tag }}"
+          if git show-ref --tags --verify --quiet "refs/tags/${tag}"; then
+            echo "Tag ${tag} already exists. Please update the version in package.json."
+            exit 1
+          fi
+          echo "Version ${tag} is new. Proceed with PR."
+        shell: bash

--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -7,18 +7,19 @@ on:
   workflow_dispatch:
 
 jobs:
-  check-branch:
-    name: Check Branch
+  quality:
+    name: Quality
+    # The quality pipeline should not take more than 15 minutes.
+    timeout-minutes: 15
     runs-on: ubuntu-latest
-    outputs:
-      skip: ${{ steps.check.outputs.skip }}
     steps:
       - name: Check if PR should skip quality gate
-        id: check
+        id: check-branch
         run: |
           base="${{ github.base_ref }}"
           head="${{ github.head_ref }}"
           skip=false
+          # PRs from develop→staging or staging→main skip the gate (already gated on develop)
           if [[ "$base" == "staging" && "$head" == "develop" ]]; then
             skip=true
           elif [[ "$base" == "main" && "$head" == "staging" ]]; then
@@ -28,24 +29,20 @@ jobs:
           echo "Base: $base | Head: $head | Skip: $skip"
         shell: bash
 
-  quality:
-    name: Quality
-    needs: check-branch
-    if: needs.check-branch.outputs.skip != true
-    timeout-minutes: 15
-    runs-on: ubuntu-latest
-    steps:
       - name: Get Info
+        if: steps.check-branch.outputs.skip != 'true'
         id: job-info
         uses: generalui/github-workflow-accelerators/.github/actions/job-info@1.0.1-job-info
 
       - name: Get changed Code Quality workflow
+        if: steps.check-branch.outputs.skip != 'true'
         id: changed-code-quality
         uses: tj-actions/changed-files@v47
         with:
           files: .github/workflows/code-quality.yml
 
       - name: Get changed markdown files
+        if: steps.check-branch.outputs.skip != 'true'
         id: changed-markdown
         uses: tj-actions/changed-files@v47
         with:
@@ -54,6 +51,7 @@ jobs:
             .markdownlint*
 
       - name: Get changed JS project files
+        if: steps.check-branch.outputs.skip != 'true'
         id: changed-js
         uses: tj-actions/changed-files@v47
         with:
@@ -69,6 +67,7 @@ jobs:
             **/*.md
 
       - name: Should lint docs
+        if: steps.check-branch.outputs.skip != 'true'
         id: lint-docs
         run: |
           run=false
@@ -81,6 +80,7 @@ jobs:
         shell: bash
 
       - name: Should run JS checks
+        if: steps.check-branch.outputs.skip != 'true'
         id: check-js
         run: |
           run=false
@@ -93,22 +93,22 @@ jobs:
         shell: bash
 
       - name: Lint all documentation
-        if: steps.lint-docs.outputs.run == true
+        if: steps.lint-docs.outputs.run == 'true'
         uses: DavidAnson/markdownlint-cli2-action@v14
         with:
           globs: |
             **/*.md
 
       - name: Lint and test
-        if: steps.check-js.outputs.run == true
+        if: steps.check-js.outputs.run == 'true'
         uses: generalui/github-workflow-accelerators/.github/actions/lint-test-yarn@main
         with:
-          checkout-code: yes
-          node-version: 20
-          upload-coverage: yes
+          checkout-code: 'yes'
+          node-version: '20'
+          upload-coverage: 'yes'
           branch: ${{ steps.job-info.outputs.pr_branch }}
 
       - name: Default Job Success
-        if: steps.lint-docs.outputs.run == false && steps.check-js.outputs.run == false
+        if: steps.lint-docs.outputs.run == 'false' && steps.check-js.outputs.run == 'false'
         run: exit 0
         shell: bash

--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -49,6 +49,10 @@ jobs:
           files: |
             **/*.md
             .markdownlint*
+          files_ignore: |
+            CLAUDE.md
+            .cursorrules
+            .github/copilot-instructions.md
 
       - name: Get changed JS project files
         if: steps.check-branch.outputs.skip != 'true'

--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -1,0 +1,114 @@
+name: Code Quality
+
+on:
+  pull_request:
+    branches: [develop, staging, main]
+    types: [opened, reopened, synchronize]
+  workflow_dispatch:
+
+jobs:
+  check-branch:
+    name: Check Branch
+    runs-on: ubuntu-latest
+    outputs:
+      skip: ${{ steps.check.outputs.skip }}
+    steps:
+      - name: Check if PR should skip quality gate
+        id: check
+        run: |
+          base="${{ github.base_ref }}"
+          head="${{ github.head_ref }}"
+          skip=false
+          if [[ "$base" == "staging" && "$head" == "develop" ]]; then
+            skip=true
+          elif [[ "$base" == "main" && "$head" == "staging" ]]; then
+            skip=true
+          fi
+          echo "skip=${skip}" >> $GITHUB_OUTPUT
+          echo "Base: $base | Head: $head | Skip: $skip"
+        shell: bash
+
+  quality:
+    name: Quality
+    needs: check-branch
+    if: needs.check-branch.outputs.skip != true
+    timeout-minutes: 15
+    runs-on: ubuntu-latest
+    steps:
+      - name: Get Info
+        id: job-info
+        uses: generalui/github-workflow-accelerators/.github/actions/job-info@1.0.1-job-info
+
+      - name: Get changed Code Quality workflow
+        id: changed-code-quality
+        uses: tj-actions/changed-files@v47
+        with:
+          files: .github/workflows/code-quality.yml
+
+      - name: Get changed markdown files
+        id: changed-markdown
+        uses: tj-actions/changed-files@v47
+        with:
+          files: |
+            **/*.md
+            .markdownlint*
+
+      - name: Get changed JS project files
+        id: changed-js
+        uses: tj-actions/changed-files@v47
+        with:
+          files: |
+            src/**
+            graphql/**
+            package.json
+            tsconfig*
+            jest*
+            .eslint*
+            .prettier*
+          files_ignore: |
+            **/*.md
+
+      - name: Should lint docs
+        id: lint-docs
+        run: |
+          run=false
+          if [[ "${{ steps.changed-markdown.outputs.any_modified }}" == "true" ]] || \
+             [[ "${{ steps.changed-code-quality.outputs.any_modified }}" == "true" ]] || \
+             [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
+            run=true
+          fi
+          echo "run=${run}" >> $GITHUB_OUTPUT
+        shell: bash
+
+      - name: Should run JS checks
+        id: check-js
+        run: |
+          run=false
+          if [[ "${{ steps.changed-js.outputs.any_modified }}" == "true" ]] || \
+             [[ "${{ steps.changed-code-quality.outputs.any_modified }}" == "true" ]] || \
+             [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
+            run=true
+          fi
+          echo "run=${run}" >> $GITHUB_OUTPUT
+        shell: bash
+
+      - name: Lint all documentation
+        if: steps.lint-docs.outputs.run == true
+        uses: DavidAnson/markdownlint-cli2-action@v14
+        with:
+          globs: |
+            **/*.md
+
+      - name: Lint and test
+        if: steps.check-js.outputs.run == true
+        uses: generalui/github-workflow-accelerators/.github/actions/lint-test-yarn@main
+        with:
+          checkout-code: yes
+          node-version: 20
+          upload-coverage: yes
+          branch: ${{ steps.job-info.outputs.pr_branch }}
+
+      - name: Default Job Success
+        if: steps.lint-docs.outputs.run == false && steps.check-js.outputs.run == false
+        run: exit 0
+        shell: bash

--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -1,0 +1,5 @@
+{
+  "default": true,
+  "MD013": false,
+  "MD033": false
+}

--- a/.markdownlintignore
+++ b/.markdownlintignore
@@ -1,0 +1,3 @@
+node_modules/
+.next/
+coverage/

--- a/.markdownlintignore
+++ b/.markdownlintignore
@@ -1,3 +1,5 @@
 node_modules/
 .next/
 coverage/
+CLAUDE.md
+.github/copilot-instructions.md

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,0 +1,2 @@
+markdownlint-cli2 0.21.0
+nodejs 20.19.0

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,61 @@
+PROJECT: MusicMeta UI
+
+MusicMeta UI is a Next.js/TypeScript web application — the primary frontend for the MusicMeta platform.
+Musicians use it to create, track, and share metadata for their musical works across the full lifecycle:
+from inspiration through composition, recording, mixing, mastering, and release.
+
+TECH STACK:
+- Next.js 14+ (App Router)
+- React 18+
+- TypeScript 5+
+- Apollo Client v3 (GraphQL, connecting to musicmeta-api)
+- Jest for unit testing
+- ESLint + Prettier for linting/formatting
+
+REPO STRUCTURE:
+- src/pages/          → Next.js pages (Pages Router)
+- src/components/     → Reusable React components
+- src/utils/          → Utility functions and helpers
+- src/constants/      → Application constants
+- graphql/            → GraphQL query/mutation files
+- public/             → Static assets
+- templates/          → Component scaffolding templates
+
+KEY CONCEPTS:
+- Work: the primary entity — a musical composition/recording. Each has a detail page.
+- WorkVersion: a snapshot fork of a Work. Versions form a tree with breadcrumb navigation.
+- People Directory: shared address book of musicians, engineers, producers.
+- Places Directory: shared list of studios and venues.
+- Credits: links Person + Role to a Work with specific instrument detail.
+- Inline editing: the Work detail page is the primary UX — click any field to edit in place.
+- Read-only share link: sharable view with field-level visibility control per Work.
+
+ARCHITECTURE:
+- GraphQL API consumed via Apollo Client (musicmeta-api Absinthe backend)
+- TypeScript types generated from GraphQL schema (graphql-codegen)
+- Auth: NextAuth.js with Google OAuth provider
+- Soft deletes only — nothing is hard-deleted
+
+CODING CONVENTIONS:
+- Functional components with TypeScript — no class components
+- Named exports only — no default exports except Next.js pages
+- Props interfaces defined in separate `*Props.ts` files (per existing template pattern)
+- Component folders: ComponentName/ComponentName.tsx + ComponentNameProps.ts + index.ts
+- `yarn lint` must pass before committing
+- `tsc --noEmit` must pass before committing
+
+TESTING:
+- `yarn test` — run full suite
+- `yarn test:coverage` — coverage report
+- Target: 20% coverage for POC (RL2), 50% for MVP (RL3)
+
+GIT:
+- Feature branches → PR to `develop`
+- `develop` → `staging` → `main`
+- PRs to `staging`/`main` from other branches require Code Quality gate
+- PRs from `develop` → `staging` or `staging` → `main` skip Code Quality (already gated)
+
+NEVER:
+- Hard-delete records (use soft delete via API)
+- Expose credentials or secrets in code or environment files committed to git
+- Commit with failing lint, type errors, or tests

--- a/package.json
+++ b/package.json
@@ -57,6 +57,6 @@
         "start": "next start",
         "init": "jest --init",
         "test": "jest",
-        "test:coverage": "jest --verbose --coverage --coverageDirectory .coverage"
+        "test:coverage": "jest --verbose --coverage"
     }
 }

--- a/src/pages/__tests__/index.test.tsx
+++ b/src/pages/__tests__/index.test.tsx
@@ -1,10 +1,7 @@
 import React from 'react'
 import { mount } from 'enzyme'
+import { MockedProvider } from '@apollo/react-testing'
 import Index from './../index'
-
-const dev = !(process.env.NODE_ENV
-    ? process.env.NODE_ENV.indexOf(`production`) + 1
-    : false);
 
 jest.mock('next/config', () => () => ({
     publicRuntimeConfig: {
@@ -16,8 +13,12 @@ jest.mock('next/config', () => () => ({
 
 describe(`index page`, () => {
     it(`should have App component`, () => {
-        const subject = mount((<Index root={`/`} />))
+        const subject = mount(
+            <MockedProvider mocks={[]} addTypename={false}>
+                <Index root={`/`} />
+            </MockedProvider>
+        )
 
-        expect(subject.find(`App`)).toHaveLength(1)
+        expect(subject.find(`MetaMusicIndex`)).toHaveLength(1)
     })
 })


### PR DESCRIPTION
## Summary

Closes #37, #38, #39

Sets up the full DevOps/code quality foundation for the MusicMeta UI per GenUI standards.

## Changes

### AI Rules Files (#37)
- `CLAUDE.md` — root-level AI context file
- `.cursorrules` — references `CLAUDE.md`
- `.github/copilot-instructions.md` — references `../CLAUDE.md`

### Code Quality Workflow (#38)
- `.github/workflows/code-quality.yml`
- Uses `generalui/github-workflow-accelerators/.github/actions/lint-test-yarn`
- Changed-files gating, coverage artifact upload
- Branch skip logic: `develop→staging` and `staging→main` skip the gate

### Check Version Workflow (#39)
- `.github/workflows/check-version.yml` — fails PR if `package.json` version tag already exists

### Markdown Lint Config
- `.markdownlint.json` and `.markdownlintignore`

## Review Notes
- Please review `CLAUDE.md` content for accuracy
- 16 open Dependabot PRs should be closed — superseded by issue #26 (full dep upgrade)